### PR TITLE
[CLAM-25] Configure LoadBalancer.

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,8 +25,10 @@ The API will progress in 2 week sprints to deliver incremental functionality.
 * The database container schema is based on migrations. If changes were made to the Clamify.Entities project you will need to add a new migration with the command found in: `BaseHelpers/ClamifyContextFactory`.
 
 ## Deployments
+Deployments are handled automatically with GitHub Actions.
 
-TBD after deployments are configured.
+- For development deployments, a push/merge into the `develop` branch will trigger a deployment to `dev.api.clamify.org`.
+- For production deployments, a new release will trigger a deployment to `api.clamify.org`.
 
 ## Code Standards
 

--- a/kubernetes/dev-deployment.yml
+++ b/kubernetes/dev-deployment.yml
@@ -5,7 +5,7 @@ metadata:
   labels:
     app: dev-clamify-api
 spec:
-  replicas: 3
+  replicas: 1
   selector:
     matchLabels:
       app: dev-clamify-api
@@ -19,4 +19,4 @@ spec:
         image: ghcr.io/cdconn00/clamify-api:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3000
+        - containerPort: 80

--- a/kubernetes/dev-ingress.yml
+++ b/kubernetes/dev-ingress.yml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    name: dev-clamify-api-ingress
+  name: dev-clamify-api-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: dev.api.clamify.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: dev-clamify-api-service
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+status:
+  loadBalancer:
+    ingress:
+    - <Load balancer external ip goes here>

--- a/kubernetes/dev-service.yml
+++ b/kubernetes/dev-service.yml
@@ -10,7 +10,7 @@ spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 3000
+    targetPort: 80
   selector:
     app: dev-clamify-api
   sessionAffinity: None

--- a/kubernetes/prod-deployment.yml
+++ b/kubernetes/prod-deployment.yml
@@ -19,4 +19,4 @@ spec:
         image: ghcr.io/cdconn00/clamify-api:latest
         imagePullPolicy: Always
         ports:
-        - containerPort: 3000
+        - containerPort: 80

--- a/kubernetes/prod-ingress.yml
+++ b/kubernetes/prod-ingress.yml
@@ -1,0 +1,24 @@
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  labels:
+    name: clamify-api-ingress
+  name: clamify-api-ingress
+  namespace: default
+spec:
+  ingressClassName: nginx
+  rules:
+  - host: api.clamify.org
+    http:
+      paths:
+      - backend:
+          service:
+            name: clamify-api-service
+            port:
+              number: 80
+        path: /
+        pathType: Prefix
+status:
+  loadBalancer:
+    ingress:
+    - <Load balancer external ip goes here>

--- a/kubernetes/prod-service.yml
+++ b/kubernetes/prod-service.yml
@@ -10,7 +10,7 @@ spec:
   ports:
   - port: 80
     protocol: TCP
-    targetPort: 3000
+    targetPort: 80
   selector:
     app: clamify-api
   sessionAffinity: None


### PR DESCRIPTION
## [CLAM-25]

---

### Summary

- Adds files associated with the load balancing/ingress setup in k8s.
- Changes the port in those files back to 80.
- Updates README with deployment info.

---

### Testing

1. Run all the unit tests.
2. Run all the integration tests.

---

### Post-Deployment Validation

- N/A, these are all just reference changes.

---


[CLAM-25]: https://clamify.atlassian.net/browse/CLAM-25?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ